### PR TITLE
changing wikipedia link to match current protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,13 +95,13 @@
 					<pre>
 						<code class="language-html">
 							&lt;!-- Example including Wikipedia in an iframe --&gt;
-							&lt;iframe data-src="http://wikipedia.org"&gt;
+							&lt;iframe data-src="//wikipedia.org"&gt;
 							&lt;/iframe&gt;
 						</code>
 					</pre>
 				</div>
 				<div>
-					<iframe data-src="http://wikipedia.org"></iframe>
+					<iframe data-src="//wikipedia.org"></iframe>
 				</div>
 			</section>
 


### PR DESCRIPTION
Had been getting the following error on https://sole.github.io/mvsd/#9 :

```
(blocked:mixed-content)
```
