### PR TITLE
handle touch events, use viewport meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>mvsd - minimally viable slide deck</title>
-		
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="stylesheet" href="vendor/prism/prism.css">
 		<script src="vendor/prism/prism.js" defer></script>
 
@@ -49,7 +49,7 @@
 					</code>
 				</pre>
 			</section>
-			
+
 			<section class="splash background-image" data-background="imgs/bg.jpg">
 				<h1>Background images can cover the whole slide</h1>
 				<h2>(and are also scaled and hardware accelerated by the browser)</h2>
@@ -89,7 +89,7 @@
 					</code>
 				</pre>
 			</section>
-	
+
 			<section class="two-columns">
 				<div>
 					<pre>

--- a/src/mvsd.js
+++ b/src/mvsd.js
@@ -2,7 +2,7 @@ function MVSD(slides) {
 
 	var currentIndex; // It's 1..indexed
 	var currentSlide;
-	
+
 	if(slides === undefined) {
 		slides = Array.from(document.querySelectorAll('section'));
 	}
@@ -20,7 +20,7 @@ function MVSD(slides) {
 					prevSlide();
 					e.preventDefault();
 					break;
-				
+
 				case 32: // space
 				case 39: // right
 					nextSlide();
@@ -39,7 +39,42 @@ function MVSD(slides) {
 			}
 		}
 	});
-	
+
+    if ('ontouchstart' in document.documentElement) {
+        var touchStates = { init: 0, moving: 1 }
+        var currentTouchState = touchStates.init
+        var startPosition = null
+        function onTouchStart (e) {
+            if (currentTouchState === touchStates.init) {
+                currentTouchState = touchStates.moving
+                var touch = e.changedTouches[0]
+                startPosition = { pageX: touch.pageX, pageY: touch.pageY }
+            }
+        }
+        function onTouchCancel () {
+            currentTouchState = touchStates.init
+            startPosition = null
+        }
+        function onTouchEnd (e) {
+            if (currentTouchState === touchStates.moving) {
+                var touch = e.changedTouches[0]
+                var minX = window.innerWidth / 4
+                // swipe left
+                if (startPosition.pageX - touch.pageX > minX) {
+                    nextSlide()
+                // swipe right
+                } else if (touch.pageX - startPosition.pageX > minX) {
+                    prevSlide()
+                }
+            }
+            startPosition = null
+            currentTouchState = touchStates.init
+        }
+        window.addEventListener('touchstart', onTouchStart)
+        window.addEventListener('touchend', onTouchEnd)
+        window.addEventListener('touchcancel',onTouchCancel)
+    }
+
 	this.onSlideChange = function() {}
 
 	gotoSlide(readHash() || 1);
@@ -95,7 +130,7 @@ function MVSD(slides) {
 	function showOneFragment() {
 		var fragments = getFragmentsAtSlide(currentIndex - 1);
 		var nextFragment;
-		
+
 		for(var i = 0; i < fragments.length; i++) {
 			var f = fragments[i];
 			if(!f.classList.contains('visible')) {
@@ -103,12 +138,12 @@ function MVSD(slides) {
 				break;
 			}
 		}
-		
+
 		if(nextFragment) {
 			showFragment(nextFragment);
 		}
 	}
-	
+
 	function getFragmentsAtSlide(index) {
 		var slide = slides[index];
 		var fragments = Array.from(slide.querySelectorAll('.fragment'));
@@ -137,7 +172,7 @@ function MVSD(slides) {
 	}
 
 	// FULL BACKGROUND IMAGES
-	
+
 	function preloadBackgroundImages(slides) {
 		// data-background to section style background value
 		slides.forEach((s) => {
@@ -182,7 +217,7 @@ function MVSD(slides) {
 	}
 
 	function enableIframesAtSlide(slide) {
-		var iframes = getSlideIframes(slide); 
+		var iframes = getSlideIframes(slide);
 		iframes.forEach(iframe => {
 			var dataSrc = iframe.dataset.src;
 			if(dataSrc) {
@@ -191,4 +226,3 @@ function MVSD(slides) {
 		});
 	}
 }
-


### PR DESCRIPTION
Fixes #2.

Use swipes to navigate between slides. Tested on iOS. Check it out on [my site](http://justinfalcone.com/mvsd).

Doesn't work _great_ but is more functional than before.

Also, my editor appears to have stripped all the trailing whitespace.